### PR TITLE
Laravel v10 upgrade fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php-http/curl-client": "^2.1",
         "bretterer/iso_duration_converter": "^0.1.0",
         "ext-json": "*",
-        "illuminate/cache": "^8.83.1 || ^9.0"
+        "illuminate/cache": "^8.83.1 || ^9.0 || ^10.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0 ",


### PR DESCRIPTION
Similar to https://github.com/echosec/laravel-vue-i18n-generator/pull/3, this PR updates the version range for this recently-unsupported package so we can upgrade to Laravel v10.